### PR TITLE
Add English translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 site
+env/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Portfolio Performance Help Pages
+
+## Setup
+
+```
+pip install -r requirements.txt
+```

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,0 +1,21 @@
+---
+title: About this handbook
+---
+
+# About this handbook
+
+[Portfolio Performance](https://portfolio-performance.info) has been available since 2012 to calculate the performance of an entire portfolio - across different accounts and portfolios - using the True-Time Weighted Rate of Return (TTWR) and Internal Rate of Return (IRR).
+
+Portfolio Performance (PP) tries to stay as simple and intuitive and possible. However, it does not always work without explanations, and seen by the numerous questions in the [forum](https://forum.portfolio-performance.info). This manual is intended to accompany you on the first steps in PP, explain basic concepts, and document features that require further explanation.
+
+## Table of Contents
+
+* [Installation](installation.md)
+* [Currencies](waehrungen.md)
+* [Loading data](kursdaten_laden.md)
+* [Recording transactions](buchungen_erfassen.md)
+
+## Contributing
+
+As you can easily see, there are many gaps in this manual. Some questions are covered in the [Frequently Asked Questions (FAQ)](https://forum.portfolio-performance.info/t/faq-haufig-gestellte-fragen/1721) in the forum. If you are interested, please take part in contributing to this manual with the pen in the top right on each page to edit directly on [Github](https://github.com/buchen/portfolio-help). If you are interested or have any questions, join us on the forum!
+

--- a/docs/installation.en.md
+++ b/docs/installation.en.md
@@ -1,0 +1,46 @@
+---
+title: Installation
+---
+
+# Installation
+
+Download the compressed file, unpack it, and start it with a double click.
+
+The XML/Portfolio file with your own data (securities, accounts, portfolios) is best saved somewhere under *My Documents*.
+
+## macOS
+
+Portfolio Performance is not signed with an Apple certificate. For this reason, [macOS Gatekeeper](https://en.wikipedia.org/wiki/Gatekeeper_(macOS)) treats this application in a special way when started for the first time. PP can be started with the following steps:
+
+
+* Load and unpack PP (for example in the "Downloads" directory)
+* Move PP to "Applications"
+* Start PP by right-clicking and selecting "Open" in the context menu and select "Open" in the subsequent dialog messages.
+
+## Linux
+
+Portfolio Performance uses [Eclipse SWT](https://www.eclipse.org/swt/), and thus native libraries in Linux. GTK3 is used by default, but sometimes there are issues with certain themes. For example, one user reported an issue related to the ["oxygen-gtk" theme](https://github.com/buchen/portfolio/issues/1089#issuecomment-459698493).
+
+You may install the dependencies in Ubuntu 18.04 by running the following command: `sudo apt install libwebkitgtk-3.0-0 default-jre`
+
+If there are issues, you may try the following workarounds:
+
+* Try a different GTK3 theme
+* Force PP to use GTK2: ```env SWT_GTK3=0 PortfolioPerformance```
+* Use an alternative input method: ```env GTK_IM_MODULE=ibus PortfolioPerformance```
+
+## Workspace directory
+
+In the *Workspace* directory, PP stores temporary data such as the current window size, recently opened files and directories, and other runtime information.
+
+The workspace directory is located at:
+
+* macOS: **~/Library/Application Support/name.abuchen.portfolio.product/workspace**
+* Windows: **%LOCALAPPDATA%\PortfolioPerformance\workspace** where %LOCALAPPDATA% is usually located at **C:\Users\\{username}\AppData\Local**
+* Linux: **~/.PortfolioPerformance/workspace**
+
+!!! note "macOS"
+    The "Library" directory is a hidden directory. The easiest way to access it is to enter "~/Library/" (without quotation marks) in Finder via the menu *Go* -> *Go to Folder...*
+
+!!! note "Windows"
+    The "LOCALAPPDATA" directory is a hidden directory. The easiest way to access it is to enter the key combination [Windows] + [R] and enter "%localappdata%" (without quotation marks) in the "Run" window.

--- a/docs/license.en.md
+++ b/docs/license.en.md
@@ -1,0 +1,13 @@
+---
+title: License
+---
+
+# License
+
+This handbook is licensed under a [Creative Commons Attribution - NonCommercial - ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+The [source code](https://github.com/buchen/portfolio) for [Portfolio Performance](https://www.portfolio-performance.info) is licensed under the [Eclipse Public License 1.0](https://github.com/buchen/portfolio/blob/master/LICENSE).
+
+## Legal Notice
+
+See [legal notice and data protection](https://www.portfolio-performance.info/portfolio/impressum.html).

--- a/docs/waehrungen.md
+++ b/docs/waehrungen.md
@@ -16,7 +16,7 @@ Portfolio Performance unterstützt Konten und Wertpapiere in Fremdwährungen.
 
 Die verfügbaren Wechselkurse finden sich unter *Allgemeine Daten -> Währungen -> Wechselkurse*.
 
-<a href="../images/assets/liste_waehrungen.png"><img alt="Allgemeine Daten - Währungen - Wechselkurse" src="../images/assets/liste_waehrungen.png" width="670" style="max-width: 670px;" class="screenshot"/></a>
+<a href="/images/assets/liste_waehrungen.png"><img alt="Allgemeine Daten - Währungen - Wechselkurse" src="/images/assets/liste_waehrungen.png" width="670" style="max-width: 670px;" class="screenshot"/></a>
 
 ## Notierung
 
@@ -47,7 +47,7 @@ Mit dem Währungsrechner unter *Allgemeine Daten -> Währungen -> Währungsrechn
 
 In diesem Beispiel wird der *Dirham* aus den Vereinige Arabische Emiraten zunächst in *US Doller* und anschliessend in *Euro* umgerechnet.
 
-<a href="../images/assets/waehrungsrechner.png"><img alt="Währungsrechner" src="../images/assets/waehrungsrechner.png" width="471" style="max-width: 471px;" class="screenshot"/></a>
+<a href="/images/assets/waehrungsrechner.png"><img alt="Währungsrechner" src="/images/assets/waehrungsrechner.png" width="471" style="max-width: 471px;" class="screenshot"/></a>
 
 PP gewichtet Wechselkurse und nutzt zur Umrechnung den Wechselkurs mit dem niedrigsten Gewicht:
 
@@ -72,21 +72,21 @@ Benutzerdefinierte Wechselkurse sind in PP nichts anderes als Wertpapiere, die n
 
 Benutzerdefinierte Wechselkurse erstellt man mit dem Dialog *Wertpapiere -> Neuen Wechselkurs anlegen...*.
 
-<a href="../images/assets/wechselkurs_anlegen.png"><img alt="Wechselkurs anlegen" src="../images/assets/wechselkurs_anlegen.png" width="654" style="max-width: 654px;" class="screenshot"/></a>
+<a href="/images/assets/wechselkurs_anlegen.png"><img alt="Wechselkurs anlegen" src="/images/assets/wechselkurs_anlegen.png" width="654" style="max-width: 654px;" class="screenshot"/></a>
 
 Neben der Währung ("Basiswährung") gibt man die Zielwährung des Wechselkurses ein.
 
-<a href="../images/assets/config_waehrungen.png"><img alt="Wechselkurs editieren" src="../images/assets/config_waehrungen.png" width="538" style="max-width: 538px;" class="screenshot"/></a>
+<a href="/images/assets/config_waehrungen.png"><img alt="Wechselkurs editieren" src="/images/assets/config_waehrungen.png" width="538" style="max-width: 538px;" class="screenshot"/></a>
 
 Um Kurse von **Yahoo Finance** zu laden, verwendet man ein Symbol aus der Basiswährung und Zielwährung mit dem Suffix **=X**. Für die Umrechnung von EUR (Euro) in den Vietnamesischen Dong (VND) heißt das Symbol entsprechnd ```EURVND=X```.
 
-<a href="../images/assets/wechselkurse_laden.png"><img alt="Wechselkurse laden" src="../images/assets/wechselkurse_laden.png" width="538" style="max-width: 538px;" class="screenshot"/></a>
+<a href="/images/assets/wechselkurse_laden.png"><img alt="Wechselkurse laden" src="/images/assets/wechselkurse_laden.png" width="538" style="max-width: 538px;" class="screenshot"/></a>
 
 Alternativ kann man die Wechselkurse auch per CSV importieren: *Datei -> Importieren... -> CSV Dateien*. Die CSV-Datei für den Kurs Euro nach Vietnamesischer Dong kann man z.B. per Google Sheets erstellen. Dazu nutzt man einfach die Funktion ```GoogleFinance``` für Euro und Dong ```CURRENCY:EURVND``` in etwa so für das letzte Jahr:
 
-<a href="../images/assets/wechselkurs_googlesheet.png"><img alt="Wechselkurs in Google Sheet laden" src="../images/assets/wechselkurs_googlesheet.png" width="519" style="max-width: 519px;" class="screenshot"/></a>
+<a href="/images/assets/wechselkurs_googlesheet.png"><img alt="Wechselkurs in Google Sheet laden" src="/images/assets/wechselkurs_googlesheet.png" width="519" style="max-width: 519px;" class="screenshot"/></a>
 
 Die Google Sheets-Datei lädt man dann als CSV herunter und importiert sie danach ganz normal mit dem CSV-Import in Portfolio Performance.
 
-<a href="../images/assets/wechselkurs_googlesheet_export.png"><img alt="Wechselkurs in Google Sheet laden" src="../images/assets/wechselkurs_googlesheet_export.png" width="617" style="max-width: 617px;" class="screenshot"/></a>
+<a href="/images/assets/wechselkurs_googlesheet_export.png"><img alt="Wechselkurs in Google Sheet laden" src="/images/assets/wechselkurs_googlesheet_export.png" width="617" style="max-width: 617px;" class="screenshot"/></a>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,16 +26,19 @@ extra_css:
 
 extra:
   social:
-    - type: 'home'
+    - icon: 'fontawesome/solid/home'
       link: 'https://www.portfolio-performance.info'
-    - type: 'github'
+    - icon: 'fontawesome/brands/github'
       link: 'https://github.com/buchen/portfolio'
-    - type: 'twitter'
+    - icon: 'fontawesome/brands/twitter'
       link: 'https://twitter.com/portfolioperf'
-    - type: 'comments-o'
+    - icon: 'fontawesome/solid/comments'
       link: 'https://forum.portfolio-performance.info'
-    - type: 'bug'
+    - icon: 'fontawesome/solid/bug'
       link: 'https://github.com/buchen/portfolio/issues'
+  analytics:
+    provider: google
+    property: UA-34744550-1
 
 markdown_extensions:
   - admonition
@@ -51,7 +54,3 @@ nav:
   - Kursdaten laden: kursdaten_laden.md
   - Buchungen erfassen: buchungen_erfassen.md
   - Lizenz: license.md
-
-google_analytics:
-  - 'UA-34744550-1'
-  - 'auto'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 
 # Project information
-site_name: 'Portfolio Performance Handbuch'
+site_name: 'Portfolio Performance'
 site_description: 'Handbuch für Portfolio Performance Software'
 site_author: 'Andreas Buchen, et. al.'
 site_url: 'https://help.portfolio-performance.info/'
@@ -36,6 +36,13 @@ extra:
       link: 'https://forum.portfolio-performance.info'
     - icon: 'fontawesome/solid/bug'
       link: 'https://github.com/buchen/portfolio/issues'
+  alternate:
+    - name: Deutsch
+      link: /
+      lang: de
+    - name: English
+      link: /en/
+      lang: en
   analytics:
     provider: google
     property: UA-34744550-1
@@ -46,6 +53,20 @@ markdown_extensions:
       guess_lang: false
   - toc:
       permalink: true
+
+plugins:
+  - i18n:
+      default_language: de
+      languages:
+        en: English
+      nav_translations:
+        en:
+          Überblick: Overview
+          Installation: Installation
+          Währungen: Currencies
+          Kursdaten laden: Loading data
+          Buchungen erfassen: Recording transactions
+          Lizenz: License
 
 nav:
   - Überblick: index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs == 1.1
-mkdocs-material == 4.6.3
+mkdocs == 1.2.3
+mkdocs-material == 8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs == 1.2.3
 mkdocs-material == 8.1.3
+mkdocs-static-i18n == 0.22

--- a/theme/partials/source.html
+++ b/theme/partials/source.html
@@ -1,4 +1,8 @@
 
-<a href="https://www.portfolio-performance.info" title="Download" class="md-header-nav__button md-logo"><i class="fa fa-download" aria-hidden="true"></i></a>
+<a href="https://www.portfolio-performance.info" title="Download" class="md-header__button md-icon twemoji">
+  {% include ".icons/fontawesome/solid/download.svg" %}
+</a>
 
-<a href="https://forum.portfolio-performance.info" title="Forum" class="md-header-nav__button md-logo"><i class="fa fa-comments-o" aria-hidden="true"></i></a>
+<a href="https://forum.portfolio-performance.info" title="Forum" class="md-header__button md-icon twemoji">
+  {% include ".icons/fontawesome/solid/comments.svg" %}
+</a>


### PR DESCRIPTION
Hi there! Thanks for creating Portfolio Performance, it's a great tool. I've started translating the documentation from Deutsche to English. I also upgraded the versions of mkdocs to support the localization package and language UI selector. I've configured it in a way to keep Deutsche as the default and under `/` to avoid breaking any links, and English under `/en/`, though it would be easy to put Deutsche under `/de/` as well if that is preferable. Pages that have not been translated fall back to the original Deutsche pages.

![Screenshot_20211220_191213](https://user-images.githubusercontent.com/929309/146849308-253df248-7fb0-4174-99a2-e14a3851bd73.png) 